### PR TITLE
Use relative path of source sass file for target css file. 

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/src/main/groovy/com/gluonhq/gradle/JavaFXTools.groovy
+++ b/src/main/groovy/com/gluonhq/gradle/JavaFXTools.groovy
@@ -1,5 +1,5 @@
 package com.gluonhq.gradle
 
 class JavaFXTools {
-    static final def fakeValue = "gluon-null"
+    static final def fakeValue = "javafx-null"
 }

--- a/src/main/groovy/com/gluonhq/gradle/ProjectAwareResolver.groovy
+++ b/src/main/groovy/com/gluonhq/gradle/ProjectAwareResolver.groovy
@@ -1,6 +1,5 @@
 package com.gluonhq.gradle
 
-import com.google.common.cache.LoadingCache
 import com.vaadin.sass.internal.ScssStylesheet
 import com.vaadin.sass.internal.resolver.FilesystemResolver
 import com.vaadin.sass.internal.resolver.ScssStylesheetResolver


### PR DESCRIPTION
This allow for keeping resulting css files in the same package as their source counterpart used to be.